### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <project.inceptionYear>2020</project.inceptionYear>
         <founder-website>https://americanexpress.io/</founder-website>
 
-        <log4j2.version>2.9.1</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <junit-jupiter.version>5.2.0</junit-jupiter.version>
         <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
         <okhttp.version>3.12.0</okhttp.version>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832